### PR TITLE
Fix duplicated decrement of poolSizeHint

### DIFF
--- a/src/main/java/org/glassfish/grizzly/thrift/client/pool/BaseObjectPool.java
+++ b/src/main/java/org/glassfish/grizzly/thrift/client/pool/BaseObjectPool.java
@@ -410,7 +410,9 @@ public class BaseObjectPool<K, V> implements ObjectPool<K, V> {
             factory.destroyObject(key, value);
         } catch (Exception ignore) {
         }
-        pool.poolSizeHint.decrementAndGet();
+        if (managed != null || removed) {
+            pool.poolSizeHint.decrementAndGet();
+        }
     }
 
     /**


### PR DESCRIPTION
When the connection is disconnected, `removeObject` can be called twice for a connection in the pool. This causes `poolSizeHint` to decrease twice. 

The problem that make an unnecessary connection occurs when `poolSizeHint` is less than the minimum size.

-------

Assume that the minimum number of connections is one and the number of connections in a pool is two.

When a connection is disconnected and called `removeObject` twice for the connection, the value of `poolSizeHint` is zero but actually another connection is in the pool.
Then, a new connection is created when next borrow because the value of `poolSizeHint` is less than minimum size. 

And continue to increase, the problem occurs when the number of idle connections reaches the maximum. Although the idle connections are in the pool, the value of `poolSizeHint` is less than minimum. So, a new connection is created every time. Then, this connection cannot be return because the idle connection queue is full.

If the traffic is heavy, it makes a lot of `TIME WAIT` connections.