### PR TITLE
Update zookeeper dependency scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,7 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper-version}</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.jmx</groupId>


### PR DESCRIPTION
Since thrift doesn't bundle zookeeper jar, the scope
for dependency can be changed to "provided" from default "compile".